### PR TITLE
adjust "time_stamp" for file: sample_41_Scene_Understanding_26-50.mp4

### DIFF
--- a/src/data/questions_omni.json
+++ b/src/data/questions_omni.json
@@ -6382,12 +6382,12 @@
         "video_path": "./videos/sample_41_Scene_Understanding_26-50.mp4"
     },
     {
-        "time": "[0:06:00 - 0:07:00]",
+        "time": "[0:04:00 - 0:05:00]",
         "questions": [
             {
                 "task_type": "Scene Understanding",
                 "question": "Please describe the scene that just occurred in the video?",
-                "time_stamp": "00:06:22",
+                "time_stamp": "00:04:22",
                 "answer": "A",
                 "options": [
                     "A. A man in a yellow raincoat and blue hat stands on a rock facing a spectacular waterfall. Music plays in the background.",

--- a/src/data/questions_omni_stream.json
+++ b/src/data/questions_omni_stream.json
@@ -5106,7 +5106,7 @@
             {
                 "task_type": "Scene Understanding",
                 "question": "Please describe the scene that just occurred in the video?",
-                "time_stamp": "00:06:22",
+                "time_stamp": "00:04:22",
                 "answer": "A",
                 "options": [
                     "A. A man in a yellow raincoat and blue hat stands on a rock facing a spectacular waterfall. Music plays in the background.",
@@ -5116,7 +5116,7 @@
                 ],
                 "required_ability": "episodic memory",
                 "audio_path": "./audio/omni/sample_41_Scene_Understanding_26-50_00_06_22.wav",
-                "time": "[0:06:00 - 0:07:00]"
+                "time": "[0:04:00 - 0:05:00]"
             }
         ],
         "video_path": "./videos/sample_41_Scene_Understanding_26-50.mp4"


### PR DESCRIPTION
The time_stamp annotation is incorrect. The file sample-41_Cene_Understanding-26-50.mp4 has a duration of 5:17, and the original time_stamp is "00:06:22", which exceeds the file duration and causes the eval.py code to report an error. According to the content of the question, adjust the value of time_damp to "00:04:22"